### PR TITLE
Support both Python 3.5 and 3.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 SHELL=/bin/bash
 export PATH := ./bin:./venv/bin:$(PATH)
 
+PYTHON ?= $(shell which python3.5 || which python3.6)
+
 ifndef ELASTIC_VERSION
 ELASTIC_VERSION := $(shell cat version.txt)
 endif
@@ -34,7 +36,7 @@ clean-test:
 	$(TEST_COMPOSE) rm --force
 
 venv: requirements.txt
-	test -d venv || virtualenv --python=python3.5 venv
+	test -d venv || virtualenv --python=$(PYTHON) venv
 	pip install -r requirements.txt
 	touch venv
 


### PR DESCRIPTION
Small change to the Makefile to support the following:
- Check for Python 3.5
- Check for, and use, Python 3.6, if 3.5 cannot be found
- Allow specifying an explicit Python path, via a new `Makefile` parameter: *PYTHON=*.

To use the new parameter, for example, you could invoke `make` like so:

`make PYTHON=special-python-3.6`

Fixes and closes #36.