### PR TITLE
Don't test permissions of headless browser files

### DIFF
--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -9,7 +9,9 @@ def exclude_browser_files(files):
     can have unexpected ownership, group or mode.
     '''
     # REF: https://github.com/elastic/kibana/blob/fe4609647dd2a7a7fedfb23d63f5886a24eacbe1/x-pack/plugins/reporting/server/browsers/install.js#L41  # noqa
-    return [f for f in files if not f.startswith('/usr/share/kibana/data/phantomjs-')]
+    files = [f for f in files if not f.startswith('/usr/share/kibana/data/phantomjs-')]
+    files = [f for f in files if not f.startswith('/usr/share/kibana/data/headless_shell-')]
+    return files
 
 
 def test_kibana_is_the_correct_version(kibana):


### PR DESCRIPTION
Kibana installs headless browsers at runtime. We can't control the
permissions of these files at build time, so we should not make
assertions about those permissions.

This patch excludes new files that were added by elastic/kibana#21788.

Fixes #99