### PR TITLE
Support for missing elasticsearch options

### DIFF
--- a/.tedi/template/kibana-docker
+++ b/.tedi/template/kibana-docker
@@ -24,6 +24,9 @@ kibana_vars=(
     elasticsearch.requestHeadersWhitelist
     elasticsearch.requestTimeout
     elasticsearch.shardTimeout
+    elasticsearch.sniffInterval
+    elasticsearch.sniffOnConnectionFault
+    elasticsearch.sniffOnStart
     elasticsearch.ssl.ca
     elasticsearch.ssl.cert
     elasticsearch.ssl.certificate

--- a/.tedi/template/kibana-docker
+++ b/.tedi/template/kibana-docker
@@ -16,6 +16,7 @@ kibana_vars=(
     console.proxyConfig
     console.proxyFilter
     elasticsearch.customHeaders
+    elasticsearch.hosts
     elasticsearch.logQueries
     elasticsearch.password
     elasticsearch.pingTimeout

--- a/.tedi/template/kibana-docker
+++ b/.tedi/template/kibana-docker
@@ -48,6 +48,7 @@ kibana_vars=(
     elasticsearch.tribe.ssl.verify
     elasticsearch.tribe.url
     elasticsearch.tribe.username
+    elasticsearch.url
     elasticsearch.username
     i18n.locale
     kibana.defaultAppId

--- a/.tedi/template/kibana-docker
+++ b/.tedi/template/kibana-docker
@@ -48,7 +48,6 @@ kibana_vars=(
     elasticsearch.tribe.ssl.verify
     elasticsearch.tribe.url
     elasticsearch.tribe.username
-    elasticsearch.url
     elasticsearch.username
     i18n.locale
     kibana.defaultAppId


### PR DESCRIPTION
Since Kibana 6.6 the option `elasticsearch.url` is not used anymore and instead we use `elasticsearch.hosts`.

For now I also left the old option enabled here.

Aside from this main added option, other elasticsearch options were also added:

```
elasticsearch.sniffInterval
elasticsearch.sniffOnConnectionFault
elasticsearch.sniffOnStart
```

This should be backported to 6.6, 6.x and 6.x-i18n branch too.

Closes https://github.com/elastic/kibana-docker/issues/120