### PR TITLE
[6.x-i18n] Support for missing elasticsearch options [#121]

### DIFF
--- a/build/kibana/bin/kibana-docker
+++ b/build/kibana/bin/kibana-docker
@@ -24,6 +24,9 @@ kibana_vars=(
     elasticsearch.requestHeadersWhitelist
     elasticsearch.requestTimeout
     elasticsearch.shardTimeout
+    elasticsearch.sniffInterval
+    elasticsearch.sniffOnConnectionFault
+    elasticsearch.sniffOnStart
     elasticsearch.ssl.ca
     elasticsearch.ssl.cert
     elasticsearch.ssl.certificate

--- a/build/kibana/bin/kibana-docker
+++ b/build/kibana/bin/kibana-docker
@@ -16,6 +16,7 @@ kibana_vars=(
     console.proxyConfig
     console.proxyFilter
     elasticsearch.customHeaders
+    elasticsearch.hosts
     elasticsearch.logQueries
     elasticsearch.password
     elasticsearch.pingTimeout

--- a/build/kibana/bin/kibana-docker
+++ b/build/kibana/bin/kibana-docker
@@ -48,6 +48,7 @@ kibana_vars=(
     elasticsearch.tribe.ssl.verify
     elasticsearch.tribe.url
     elasticsearch.tribe.username
+    elasticsearch.url
     elasticsearch.username
     i18n.locale
     kibana.defaultAppId

--- a/build/kibana/bin/kibana-docker
+++ b/build/kibana/bin/kibana-docker
@@ -48,7 +48,6 @@ kibana_vars=(
     elasticsearch.tribe.ssl.verify
     elasticsearch.tribe.url
     elasticsearch.tribe.username
-    elasticsearch.url
     elasticsearch.username
     i18n.locale
     kibana.defaultAppId


### PR DESCRIPTION
Backports the commits on https://github.com/elastic/kibana-docker/pull/121 to [6.x-i18n](https://github.com/elastic/kibana-docker/tree/6.x-i18n)