### PR TITLE
set default elasticsearch.hosts in kibana.yml

### DIFF
--- a/build/kibana/config/kibana-full.yml
+++ b/build/kibana/config/kibana-full.yml
@@ -3,5 +3,5 @@
 
 server.name: kibana
 server.host: "0"
-elasticsearch.url: http://elasticsearch:9200
+elasticsearch.hosts: http://elasticsearch:9200
 xpack.monitoring.ui.container.elasticsearch.enabled: true

--- a/build/kibana/config/kibana-oss.yml
+++ b/build/kibana/config/kibana-oss.yml
@@ -3,4 +3,4 @@
 
 server.name: kibana
 server.host: "0"
-elasticsearch.url: http://elasticsearch:9200
+elasticsearch.hosts: http://elasticsearch:9200


### PR DESCRIPTION
Deprecations currently break configuration order of operations.

`bin/kibana --elasticsearch.hosts` will take precendence over a kibana.yml `elasticsearch.hosts`, but not url.  The deprecations script will run and overwrite it.

This is a patch fix, we'll have to get something more thorough sorted in core.

cc @elastic/kibana-operations 